### PR TITLE
Declaratively autoload mode and give it human-readable name

### DIFF
--- a/jenkinsfile-mode.el
+++ b/jenkinsfile-mode.el
@@ -61,7 +61,8 @@
 (setq jenkinsfile-mode-font-lock-defaults
       (append groovy-font-lock-keywords jenkinsfile-mode-font-lock-keywords))
 
-(define-derived-mode jenkinsfile-mode groovy-mode "jenkinsfile-mode"
+;;;###autoload
+(define-derived-mode jenkinsfile-mode groovy-mode "Jenkinsfile"
   "Major mode for editing Jenkins declarative pipeline files."
   (setq font-lock-defaults '(jenkinsfile-mode-font-lock-defaults)))
 


### PR DESCRIPTION
1. The `;;;###autoload` magic comment is the Emacs standard way of declaring autoloads. It's more efficient, as, having been placed on a major mode declaration, it creates a mode stub such that it can still be explored and documented without being fully loaded. This probably supersedes the less kosher attempt in #2 that causes the mode to load early and unconditionally. @ben-bourdin451, I invite you to please voice your arguments if you find your approach better! I do in good faith reasonably reduce a potential of contention here, which will make the code better in the end.

2. Name the mode with a human-readable string, according to the documented intent of the NAME argument of the mode declaration. You normally see "Groovy" or "Makefile"in the modeline, not "groovy-mode" or "makefile-mode".