### PR TITLE
Fix void-variable error

### DIFF
--- a/jenkinsfile-mode.el
+++ b/jenkinsfile-mode.el
@@ -295,7 +295,7 @@ Run this manually when editing this file to get an updated the list of keywords.
   (add-hook 'completion-at-point-functions 'jenkinsfile-mode--option-compeletion-at-point nil 'local)
   (add-hook 'completion-at-point-functions 'jenkinsfile-mode--pipeline-step-compeletion-at-point nil 'local)
   (add-hook 'completion-at-point-functions 'jenkinsfile-mode--core-step-compeletion-at-point nil 'local)
-  (when (boundp 'company-mode)
+  (with-eval-after-load 'company-keywords)
     (add-to-list 'company-keywords-alist
                  `(jenkinsfile-mode . ,(append jenkinsfile-mode--file-section-keywords
                                                jenkinsfile-mode--directive-keywords


### PR DESCRIPTION
When `company-mode` is loading, `company-keywords` is not necessarily loaded, so `company-keywords-alist` could be out of scope and referencing it will result in a `void-variable` error. This PR fixes this issue and also schedule that block of code to run after `company-keywords` is loaded, thus the user don't have to guarantee `company-mode` is always loaded before jenkinsfile-mode.