### PR TITLE
Fix elisp parse error by removing extraneous parenthesis

### DIFF
--- a/jenkinsfile-mode.el
+++ b/jenkinsfile-mode.el
@@ -295,7 +295,7 @@ Run this manually when editing this file to get an updated the list of keywords.
   (add-hook 'completion-at-point-functions 'jenkinsfile-mode--option-compeletion-at-point nil 'local)
   (add-hook 'completion-at-point-functions 'jenkinsfile-mode--pipeline-step-compeletion-at-point nil 'local)
   (add-hook 'completion-at-point-functions 'jenkinsfile-mode--core-step-compeletion-at-point nil 'local)
-  (with-eval-after-load 'company-keywords)
+  (with-eval-after-load 'company-keywords
     (add-to-list 'company-keywords-alist
                  `(jenkinsfile-mode . ,(append jenkinsfile-mode--file-section-keywords
                                                jenkinsfile-mode--directive-keywords


### PR DESCRIPTION
The error was:

    error: jenkinsfile-mode.el:0:0: error: scan-error: (Containing
    expression ends prematurely 17059 17060)