### PR TITLE
Resolve all compile warnings

### DIFF
--- a/jenkinsfile-mode.el
+++ b/jenkinsfile-mode.el
@@ -27,6 +27,8 @@
 
 (require 'groovy-mode)
 
+(defvar company-keywords-alist) ; defined in company-keywords.el
+
 (defcustom jenkinsfile-mode-vim-source-url
   "https://raw.githubusercontent.com/martinda/Jenkinsfile-vim-syntax/master/syntax/Jenkinsfile.vim"
   "URL to Jenkinsfile.vim source file."


### PR DESCRIPTION
Previously, compiling would result in the following warnings:

    $ emacs -Q --batch -L ~/.emacs.d/elpa/groovy-mode-20220212.646 -L ~/.emacs.d/elpa/s-20220902.1511 -L ~/.emacs.d/elpa/dash-20221013.836 -f batch-native-compile jenkinsfile-mode.el

    In jenkinsfile-mode:
    jenkinsfile-mode.el:299:19: Warning: reference to free variable
        ‘company-keywords-alist’
    jenkinsfile-mode.el:299:19: Warning: assignment to free variable
        ‘company-keywords-alist’

These have been fixed by declaring company-keywords-alist with defvar.