### PR TITLE
Remove commas from keyword list

### DIFF
--- a/jenkinsfile-mode.el
+++ b/jenkinsfile-mode.el
@@ -199,7 +199,7 @@
     "writeJSON" "writeMavenPom" "writeProperties" "writeXml" "writeYaml"
     "ws" "xUnitImporter" "xUnitUploader" "xunit" "xldCreatePackage"
     "xldDeploy" "xldPublishPackage" "xlrCreateRelease" "xrayScanBuild"
-    "zip", "matrix", "axes", "axis"))
+    "zip" "matrix" "axes" "axis"))
 
 
 (defun jenkinsfile-mode--fetch-keywords-from-jenkinsfile-vim ()


### PR DESCRIPTION
The keyword list has commas that causes the mode to crash when enabled